### PR TITLE
Better naming; pass back pyerror instead of rust panic

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,9 @@ jobs:
           sccache: 'true'
           manylinux: auto
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-linux-${{ matrix.target }}
           path: dist
 
   windows:
@@ -60,9 +60,9 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-windows-${{ matrix.target }}
           path: dist
 
   macos:
@@ -82,9 +82,9 @@ jobs:
           args: --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-macos-${{ matrix.target }}
           path: dist
 
   sdist:
@@ -97,9 +97,9 @@ jobs:
           command: sdist
           args: --out dist
       - name: Upload sdist
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
-          name: wheels
+          name: wheels-sdist
           path: dist
 
   release:
@@ -110,9 +110,10 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
-          name: wheels
+          pattern: wheels-*
+          merge-multiple: true
       - name: Publish to PyPI
         uses: PyO3/maturin-action@v1
         with:

--- a/ruhvro/README.md
+++ b/ruhvro/README.md
@@ -33,11 +33,11 @@ fn main() {
     let serialized = apache_avro::to_avro_datum(&parsed_schema, record).unwrap();
     
     // deserialization
-     let deserialized = ruhvro::deserialize::per_datum_deserialize(&vec![&serialized[..]], &parsed_schema);
+     let deserialized = ruhvro::deserialize::per_datum_deserialize(&vec![&serialized[..]], &parsed_schema).unwrap();
      println!("{:?}", deserialized);
     
      // serialize the record batch
-     let serialized = ruhvro::serialize::serialize_record_batch(deserialized, &parsed_schema, 1);
+     let serialized = ruhvro::serialize::serialize_record_batch(deserialized, &parsed_schema, 1).unwrap();
      println!("{:?}", serialized);
 }
 ```

--- a/ruhvro/src/complex.rs
+++ b/ruhvro/src/complex.rs
@@ -680,7 +680,6 @@ mod tests {
     }
     #[test]
     fn test_map_array() {
-        // fix asserts. Map values can return different order so test will fail 50% of the time
         let k_field = Field::new("keys", DataType::Utf8, false);
         let v_field = Field::new("values", DataType::Int32, false);
         let struct_field = Arc::new(Field::new(
@@ -708,10 +707,15 @@ mod tests {
             .as_any()
             .downcast_ref::<Int32Array>()
             .unwrap();
-        let expected_keys = StringArray::from(vec!["my_key", "second"]);
-        let expected_values = Int32Array::from(vec![1, 3]);
-        assert_eq!(key_result, &expected_keys);
-        assert_eq!(value_result, &expected_values);
+        // HashMap iteration order is non-deterministic, but key↔value pairing
+        // must be preserved. Sort pairs by key before comparing.
+        let mut actual: Vec<(&str, i32)> = key_result
+            .iter()
+            .zip(value_result.iter())
+            .map(|(k, v)| (k.unwrap(), v.unwrap()))
+            .collect();
+        actual.sort_by_key(|(k, _)| *k);
+        assert_eq!(actual, vec![("my_key", 1), ("second", 3)]);
     }
     #[test]
     fn test_nested_struct() {

--- a/ruhvro/src/deserialize.rs
+++ b/ruhvro/src/deserialize.rs
@@ -2,7 +2,7 @@ use crate::complex::StructContainer;
 use crate::schema_translate::to_arrow_schema;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{anyhow, Result};
 use apache_avro::from_avro_datum;
 use apache_avro::Schema as AvroSchema;
 use arrow::array::{Array, BinaryArray, RecordBatch};
@@ -20,16 +20,17 @@ pub fn parse_schema(schema_string: &str) -> Result<AvroSchema> {
 
 /// Single threaded, takes a Vec of binary encoded schemaless avro and the parsed avro
 /// schema to read them.
-pub fn per_datum_deserialize(data: &Vec<&[u8]>, schema: &AvroSchema) -> RecordBatch {
-    let fields = to_arrow_schema(schema).unwrap().fields;
-    let mut builder = StructContainer::try_new_from_fields(fields, data.len()).unwrap();
-    data.into_iter().for_each(|datum| {
+pub fn per_datum_deserialize(data: &Vec<&[u8]>, schema: &AvroSchema) -> Result<RecordBatch> {
+    let fields = to_arrow_schema(schema)?.fields;
+    let mut builder = StructContainer::try_new_from_fields(fields, data.len())?;
+    data.into_iter().try_for_each(|datum| {
         let mut sliced = &datum[..];
-        let avro = from_avro_datum(schema, &mut sliced, None).unwrap();
+        let avro = from_avro_datum(schema, &mut sliced, None)?;
         let _ = builder.add_val(&avro);
-    });
-    let sa = builder.try_build_struct_array().unwrap();
-    sa.into()
+        Ok::<(), anyhow::Error>(())
+    })?;
+    let sa = builder.try_build_struct_array()?;
+    Ok(sa.into())
 }
 
 /// Deserializes vector of serialized avro messages with many threads.
@@ -37,8 +38,8 @@ pub fn per_datum_deserialize_threaded(
     data: Vec<&[u8]>,
     schema: &AvroSchema,
     num_chunks: usize,
-) -> Vec<RecordBatch> {
-    let arrow_schema = Arc::new(to_arrow_schema(schema).unwrap());
+) -> Result<Vec<RecordBatch>> {
+    let arrow_schema = Arc::new(to_arrow_schema(schema)?);
     let fields = &arrow_schema.fields;
     let arr = Arc::new(BinaryArray::from_vec(data));
     let mut slices = vec![];
@@ -55,20 +56,22 @@ pub fn per_datum_deserialize_threaded(
         .par_iter()
         .map(|da| {
             // let mut builder = StructBuilder::from_fields(fields.clone(), data.len());
+
             let mut builder =
-                StructContainer::try_new_from_fields(fields.clone(), arr.len()).unwrap();
-            da.iter().for_each(|avro_data| {
-                let mut sliced = avro_data.unwrap();
-                let deserialized = from_avro_datum(schema, &mut sliced, None).unwrap();
+                StructContainer::try_new_from_fields(fields.clone(), arr.len())?;
+            da.iter().try_for_each(|avro_data| {
+                let mut sliced = avro_data.ok_or(anyhow!("Error getting sliced data"))?;
+                let deserialized = from_avro_datum(schema, &mut sliced, None)?;
                 let _ = builder.add_val(&deserialized);
-            });
+                Ok::<(), anyhow::Error>(())
+            })?;
             let d = builder
                 .try_build_struct_array()
                 .expect("Failed to build struct from record");
             let dd: RecordBatch = d.into();
-            dd
+            Ok(dd)
         })
-        .collect::<Vec<_>>();
+        .collect();
     r
 }
 
@@ -146,7 +149,7 @@ mod tests {
         let avro_datum = "4834346437643065662d613264662d343833652d393261312d313532333830366164656334380a4c696e64610857617265022c6c696e646173636f7474406578616d706c652e6e6574062628323636293734302d31323737783031313432283030312d3935392d3839342d36353030783739392a3030312d3339362d3831392d363830307830303139000006044d72100866696e640e10617070726f6163680c00c0f691c7c35f";
         let encoded = decode_hex(avro_datum);
         let newv = vec![&encoded[..], &encoded[..], &encoded[..], &encoded[..]];
-        let result = per_datum_deserialize(&newv, &parsed_schema);
+        let result = per_datum_deserialize(&newv, &parsed_schema).unwrap();
         assert_eq!(result.num_columns(), 8);
         assert_eq!(result.num_rows(), 4);
     }
@@ -205,7 +208,7 @@ mod tests {
         let avro_datum = "084a6f686e06446f653c041431323320456c6d20537412536f6d6577686572650a313233343514343536204f616b20537410416e7977686572650a36373839300002286a6f686e2e646f65406578616d706c652e636f6d";
         let encoded = decode_hex(avro_datum);
         let newv = vec![&encoded[..]];
-        let result = per_datum_deserialize(&newv, &parsed_schema);
+        let result = per_datum_deserialize(&newv, &parsed_schema).unwrap();
         assert_eq!(result.num_rows(), 1);
         assert_eq!(result.num_columns(), 5);
     }
@@ -243,7 +246,7 @@ mod tests {
         record2.put("c", "hearts");
         let serialized2 = to_avro_datum(&schema, record2).unwrap();
         let a = vec![&serialized[..], &serialized2[..]];
-        let arr = per_datum_deserialize(&a, &schema);
+        let arr = per_datum_deserialize(&a, &schema).unwrap();
         assert_eq!(arr.num_columns(), 3);
         assert_eq!(arr.num_rows(), 2);
         let enum_vec = arr
@@ -275,7 +278,7 @@ mod tests {
         record.put("a", 27i64);
         record.put("b", None::<String>);
         let serialized = to_avro_datum(&parsed_schema, record).unwrap();
-        let result = per_datum_deserialize(&vec![&serialized[..]], &parsed_schema);
+        let result = per_datum_deserialize(&vec![&serialized[..]], &parsed_schema).unwrap();
         assert_eq!(result.num_columns(), 2);
     }
 }

--- a/ruhvro/src/lib.rs
+++ b/ruhvro/src/lib.rs
@@ -32,11 +32,11 @@ mod complex;
 /// // and serialize it
 /// let serialized = apache_avro::to_avro_datum(&parsed_schema, record).unwrap();
 /// // verify deserialization
-/// let deserialized = ruhvro::deserialize::per_datum_deserialize(&vec![&serialized[..]], &parsed_schema);
+/// let deserialized = ruhvro::deserialize::per_datum_deserialize(&vec![&serialized[..]], &parsed_schema).unwrap();
 /// println!("{:?}", deserialized);
 ///
 /// // serialize the record batch
-/// let serialized = ruhvro::serialize::serialize_record_batch(deserialized, &parsed_schema, 1);
+/// let serialized = ruhvro::serialize::serialize_record_batch(deserialized, &parsed_schema, 1).unwrap();
 /// println!("{:?}", serialized);
 ///
 ///
@@ -151,6 +151,7 @@ mod tests {
         "#;
 
         let parsed_schema = crate::deserialize::parse_schema(&schema).unwrap();
+        // let avro_datum = "0000062e74686f6d61736b6172656e406578616d706c652e6e657422616c6f7765406578616d706c652e6f72672664617669643738406578616d706c652e636f6d0000060a636865636b203030312d3233372d3438302d353133341065766964656e6365262b312d3732352d3336362d39323133783730300a6d616a6f722428393734293537302d3032313178333534350002020a656d61696c00020a7374616666";
         let avro_datum = "0000062e74686f6d61736b6172656e406578616d706c652e6e657422616c6f7765406578616d706c652e6f72672664617669643738406578616d706c652e636f6d0000060a636865636b203030312d3233372d3438302d353133341065766964656e6365262b312d3732352d3336362d39323133783730300a6d616a6f722428393734293537302d3032313178333534350002020a656d61696c00020a7374616666";
         let avro_datum2 = "0218416d616e646120456c6c6973023804246e6361736579406578616d706c652e636f6d307374657761727474796c6572406578616d706c652e6e6574000230393532323120436861726c657320547261666669637761791c5a616368617279626f726f7567680a303433343300000202";
         let avro_datum3 = "021a417564726579204261726e65730000000408726963682628373136293338322d363937327837383437320e746f6e69676874243536302e3736352e3230363378373831313500020000000866726565";
@@ -158,9 +159,9 @@ mod tests {
         let encoded2 = decode_hex(avro_datum2);
         let encoded3 = decode_hex(avro_datum3);
         let newv = vec![&encoded[..], &encoded2[..], &encoded3[..]];
-        let result = per_datum_deserialize(&newv, &parsed_schema);
+        let result = per_datum_deserialize(&newv, &parsed_schema).unwrap();
 
-        let serialized = crate::serialize::serialize_record_batch(result, &parsed_schema, 1);
+        let serialized = crate::serialize::serialize_record_batch(result, &parsed_schema, 1).unwrap();
 
     }
 

--- a/ruhvro/src/schema_translate.rs
+++ b/ruhvro/src/schema_translate.rs
@@ -100,7 +100,7 @@ fn schema_to_field_with_props(
                 DataType::Union(UnionFields::new(type_ids, fields), UnionMode::Sparse)
             }
         }
-        AvroSchema::Record(RecordSchema { name, fields, .. }) => {
+        AvroSchema::Record(RecordSchema { fields, .. }) => {
             let fields: Result<_> = fields
                 .iter()
                 .map(|field| {
@@ -108,12 +108,9 @@ fn schema_to_field_with_props(
                     if let Some(doc) = &field.doc {
                         props.insert("avro::doc".to_string(), doc.clone());
                     }
-                    /*if let Some(aliases) = fields.aliases {
-                        props.insert("aliases", aliases);
-                    }*/
                     schema_to_field_with_props(
                         &field.schema,
-                        Some(&format!("{}.{}", name.fullname(None), field.name)),
+                        Some(&field.name),
                         nullable,
                         Some(props),
                     )
@@ -122,8 +119,14 @@ fn schema_to_field_with_props(
             DataType::Struct(fields?)
         }
         AvroSchema::Enum(EnumSchema {
-            symbols: _, name, ..
-        }) => return Ok(Field::new(name.fullname(None), DataType::Utf8, nullable)),
+            symbols: _, name: enum_name, ..
+        }) => {
+            let field_name = match name {
+                Some(n) if !n.is_empty() => n.to_string(),
+                _ => enum_name.fullname(None),
+            };
+            return Ok(Field::new(field_name, DataType::Utf8, nullable));
+        }
         AvroSchema::Fixed(FixedSchema { size, .. }) => DataType::FixedSizeBinary(*size as i32),
         AvroSchema::Decimal(DecimalSchema {
             precision, scale, ..
@@ -293,4 +296,43 @@ fn test_sample() {
     let avro_schema = AvroSchema::parse_str(schema).unwrap();
     let arrow_schema = to_arrow_schema(&avro_schema).unwrap();
     println!("{:?}", arrow_schema);
+}
+
+#[test]
+fn test_field_names_use_avro_field_name() {
+    let schema = r#"
+        {
+            "type": "record",
+            "name": "User",
+            "namespace": "com.example",
+            "fields": [
+                {"name": "userid", "type": "string"},
+                {"name": "address", "type": ["null", {
+                    "type": "record",
+                    "name": "Address",
+                    "fields": [
+                        {"name": "street", "type": "string"},
+                        {"name": "city", "type": "string"}
+                    ]
+                }], "default": null},
+                {"name": "class", "type": {
+                    "type": "enum",
+                    "name": "ClassEnum",
+                    "symbols": ["A", "B", "C"]
+                }}
+            ]
+        }
+    "#;
+    let avro_schema = AvroSchema::parse_str(schema).unwrap();
+    let arrow_schema = to_arrow_schema(&avro_schema).unwrap();
+    let names: Vec<&str> = arrow_schema.fields().iter().map(|f| f.name().as_str()).collect();
+    assert_eq!(names, vec!["userid", "address", "class"]);
+
+    let address_field = arrow_schema.field_with_name("address").unwrap();
+    if let DataType::Struct(nested) = address_field.data_type() {
+        let nested_names: Vec<&str> = nested.iter().map(|f| f.name().as_str()).collect();
+        assert_eq!(nested_names, vec!["street", "city"]);
+    } else {
+        panic!("expected struct for address field");
+    }
 }

--- a/ruhvro/src/serialization_containers.rs
+++ b/ruhvro/src/serialization_containers.rs
@@ -10,15 +10,15 @@ use arrow::buffer::{NullBuffer, OffsetBuffer, ScalarBuffer};
 use arrow::datatypes::{Float32Type, Float64Type, Int32Type, Int64Type, TimestampMillisecondType};
 use std::collections::HashMap;
 
-pub fn serialize(schema: &Schema, struct_arry: &ArrayRef) -> GenericBinaryArray<i32> {
-    let mut arr_container = ArrayContainers::try_new(struct_arry, schema).unwrap();
+pub fn serialize(schema: &Schema, struct_arry: &ArrayRef) -> anyhow::Result<GenericBinaryArray<i32>> {
+    let mut arr_container = ArrayContainers::try_new(struct_arry, schema)?;
     let mut builder = GenericBinaryBuilder::new();
     (0..struct_arry.len()).for_each(|_| {
         let val = arr_container.get_next();
         let serialized = to_avro_datum(schema, val).unwrap();
         builder.append_value(serialized);
     });
-    builder.finish()
+    Ok(builder.finish())
 }
 
 /// Checks if column should be encoded as an avro union type
@@ -245,20 +245,33 @@ impl<'a> StructArrayContainer<'a> {
         let mut column_names = vec![];
         let inner_arrays: anyhow::Result<Vec<ArrayContainers>> = if let Schema::Record(rs) = schema
         {
-            let schemas = &rs.fields;
-            (0..schemas.len())
-                .map(|idx| {
-                    column_names.push(String::from(&schemas[idx].name));
-                    Ok(ArrayContainers::try_new(
-                        data.column(idx),
-                        &schemas[idx].schema,
-                    )?)
+            let arrow_name_to_idx: HashMap<&str, usize> = data
+                .fields()
+                .iter()
+                .enumerate()
+                .map(|(i, f)| (f.name().as_str(), i))
+                .collect();
+            rs.fields
+                .iter()
+                .map(|avro_field| {
+                    let arrow_idx = arrow_name_to_idx
+                        .get(avro_field.name.as_str())
+                        .ok_or_else(|| {
+                            let available: Vec<&str> =
+                                data.fields().iter().map(|f| f.name().as_str()).collect();
+                            anyhow!(
+                                "Arrow struct missing column '{}' required by Avro schema. Available columns: {:?}",
+                                avro_field.name,
+                                available
+                            )
+                        })?;
+                    column_names.push(avro_field.name.clone());
+                    ArrayContainers::try_new(data.column(*arrow_idx), &avro_field.schema)
                 })
                 .collect()
         } else {
             panic!("Expected record schema");
         };
-        // let null_buff = None;
         let null_buff = data.nulls();
         Ok(StructArrayContainer {
             data: inner_arrays?,

--- a/ruhvro/src/serialize.rs
+++ b/ruhvro/src/serialize.rs
@@ -5,6 +5,7 @@ use arrow::array::{
 use rayon::prelude::*;
 use std::sync::Arc;
 use crate::serialization_containers;
+use anyhow::Result;
 // TODO: Should be checks to make sure avro and arrow schema match
 // TODO: need to figure out names. Should serialize match by name or position?
 // TODO: Should it include namespace in matching?
@@ -29,7 +30,7 @@ pub fn serialize_record_batch(
     rb: RecordBatch,
     schema: &Schema,
     num_chunks: usize,
-) -> Vec<GenericBinaryArray<i32>> {
+) -> Result<Vec<GenericBinaryArray<i32>>> {
     let struct_arry: ArrayRef = Arc::<StructArray>::new(rb.into());
     let chunk_size = struct_arry.len() / num_chunks;
     let slices: Vec<_> = (0..num_chunks)
@@ -139,14 +140,14 @@ mod test {
         let schema = Schema::parse_str(avro_schema).unwrap();
         // let struct_arr_ref: ArrayRef = Arc::new(struct_arr);
         let struct_arr_ref: RecordBatch = struct_arr.into();
-        let r = serialize_record_batch(struct_arr_ref.clone(), &schema, 1);
+        let r = serialize_record_batch(struct_arr_ref.clone(), &schema, 1).unwrap();
         let ra = r
             .iter()
             .map(|x| x.iter().map(|j| j.unwrap()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
 
         //
-        let deserialize = crate::deserialize::per_datum_deserialize(&ra[0], &schema);
+        let deserialize = crate::deserialize::per_datum_deserialize(&ra[0], &schema).unwrap();
         let rb = struct_arr_ref;
         assert_eq!(deserialize, rb);
     }
@@ -197,12 +198,12 @@ mod test {
         );
         let arr: RecordBatch = outer_struct_arr.into();
         let parsed_schmea = Schema::parse_str(schmea).unwrap();
-        let arr_cont = serialize_record_batch(arr.clone(), &parsed_schmea, 1);
+        let arr_cont = serialize_record_batch(arr.clone(), &parsed_schmea, 1).unwrap();
         let ra = arr_cont
             .iter()
             .map(|x| x.iter().map(|j| j.unwrap()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
-        let deserialized = crate::deserialize::per_datum_deserialize(&ra[0], &parsed_schmea);
+        let deserialized = crate::deserialize::per_datum_deserialize(&ra[0], &parsed_schmea).unwrap();
         // assert_eq!(arr, deserialized);
     }
     #[test]
@@ -244,12 +245,12 @@ mod test {
         let schema = Schema::parse_str(schema).unwrap();
         let record_arr_ref: RecordBatch = record_arr.into();
         println!("{:?}", record_arr_ref);
-        let r = serialize_record_batch(record_arr_ref.clone(), &schema, 1);
+        let r = serialize_record_batch(record_arr_ref.clone(), &schema, 1).unwrap();
         let ra = r
             .iter()
             .map(|x| x.iter().map(|j| j.unwrap()).collect::<Vec<_>>())
             .collect::<Vec<_>>();
-        let deserialized = crate::deserialize::per_datum_deserialize(&ra[0], &schema);
+        let deserialized = crate::deserialize::per_datum_deserialize(&ra[0], &schema).unwrap();
         assert_eq!(record_arr_ref, deserialized);
     }
 
@@ -301,5 +302,68 @@ mod test {
         // let arr: ArrayRef = Arc::new(outer_struct_arr);
         // let parsed_schmea = Schema::parse_str(schmea).unwrap();
         // let arr_cont = serialize_record_batch(arr.clone(), &parsed_schmea, 1);
+    }
+
+    #[test]
+    fn test_serialize_matches_columns_by_name() {
+        // Arrow RecordBatch has columns in a different order than the Avro schema.
+        // Serialization should still succeed and produce the same bytes as if they
+        // matched the schema order, because matching is now by name.
+        let schema_str = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "a", "type": "int"},
+                    {"name": "b", "type": "string"}
+                ]
+            }
+        "#;
+        let parsed = Schema::parse_str(schema_str).unwrap();
+
+        let a_arr: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let b_arr: ArrayRef = Arc::new(StringArray::from(vec!["x", "y", "z"]));
+
+        // Build in (a, b) order — matches schema.
+        let in_order = RecordBatch::try_from_iter(vec![
+            ("a", a_arr.clone()),
+            ("b", b_arr.clone()),
+        ]).unwrap();
+        // Build in (b, a) order — reversed relative to schema.
+        let reversed = RecordBatch::try_from_iter(vec![
+            ("b", b_arr.clone()),
+            ("a", a_arr.clone()),
+        ]).unwrap();
+
+        let in_order_bytes = serialize_record_batch(in_order, &parsed, 1).unwrap();
+        let reversed_bytes = serialize_record_batch(reversed, &parsed, 1).unwrap();
+
+        assert_eq!(in_order_bytes.len(), reversed_bytes.len());
+        for (a, b) in in_order_bytes.iter().zip(reversed_bytes.iter()) {
+            assert_eq!(a.value_data(), b.value_data());
+        }
+    }
+
+    #[test]
+    fn test_serialize_errors_on_missing_column() {
+        let schema_str = r#"
+            {
+                "type": "record",
+                "name": "test",
+                "fields": [
+                    {"name": "a", "type": "int"},
+                    {"name": "b", "type": "string"}
+                ]
+            }
+        "#;
+        let parsed = Schema::parse_str(schema_str).unwrap();
+
+        // Only one of the two required columns is present.
+        let a_arr: ArrayRef = Arc::new(Int32Array::from(vec![1, 2, 3]));
+        let batch = RecordBatch::try_from_iter(vec![("a", a_arr)]).unwrap();
+
+        let err = serialize_record_batch(batch, &parsed, 1).unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("missing column 'b'"), "unexpected error: {msg}");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,50 +3,58 @@
 //!
 use arrow::array::{Array, ArrayData, RecordBatch};
 use arrow::pyarrow::PyArrowType;
+use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyList;
 use ruhvro::deserialize;
 use ruhvro::serialize;
 
+fn to_py_err<E: std::fmt::Display>(e: E) -> PyErr {
+    PyValueError::new_err(e.to_string())
+}
+
 #[pyfunction]
 fn deserialize_array(list: &PyList, schema: &str) -> PyResult<PyArrowType<RecordBatch>> {
-    let parsed_schema = deserialize::parse_schema(schema).unwrap();
+    let parsed_schema = deserialize::parse_schema(schema).map_err(to_py_err)?;
     let borrow_list = list
         .iter()
-        .map(|x| x.extract::<&[u8]>().unwrap())
-        .collect::<Vec<_>>();
-    let record_batch = deserialize::per_datum_deserialize(&borrow_list, &parsed_schema);
+        .map(|x| x.extract::<&[u8]>())
+        .collect::<PyResult<Vec<_>>>()?;
+    let record_batch =
+        deserialize::per_datum_deserialize(&borrow_list, &parsed_schema).map_err(to_py_err)?;
     Ok(PyArrowType(record_batch))
 }
+
 #[pyfunction]
 fn deserialize_array_threaded(
     list: &PyList,
     schema: &str,
     num_chunks: usize,
 ) -> PyResult<Vec<PyArrowType<RecordBatch>>> {
-    let parsed_schema = deserialize::parse_schema(schema).unwrap();
+    let parsed_schema = deserialize::parse_schema(schema).map_err(to_py_err)?;
     let borrow_list = list
         .iter()
-        .map(|x| x.extract::<&[u8]>().unwrap())
-        .collect::<Vec<_>>();
+        .map(|x| x.extract::<&[u8]>())
+        .collect::<PyResult<Vec<_>>>()?;
     let record_batches =
-        deserialize::per_datum_deserialize_threaded(borrow_list, &parsed_schema, num_chunks);
-    let python_typed_batches = record_batches
-        .into_iter()
-        .map(|x| PyArrowType(x))
-        .collect::<Vec<_>>();
-    Ok(python_typed_batches)
+        deserialize::per_datum_deserialize_threaded(borrow_list, &parsed_schema, num_chunks)
+            .map_err(to_py_err)?;
+    Ok(record_batches.into_iter().map(PyArrowType).collect())
 }
 
 #[pyfunction]
-fn serialize_record_batch(data: PyArrowType<RecordBatch>, schema: &str, num_chunks: usize) -> PyResult<Vec<PyArrowType<ArrayData>>> {
-    let parsed_schema = deserialize::parse_schema(schema).unwrap();
-    let d = data.0;
-    let serialized = serialize::serialize_record_batch(d, &parsed_schema, num_chunks);
-    let python_typed_batches = serialized.into_iter()
-        .map(|x| PyArrowType(x.into_data())).collect::<Vec<_>>();
-    // Ok(PyArrowType(serialized.into_data()))
-    Ok(python_typed_batches)
+fn serialize_record_batch(
+    data: PyArrowType<RecordBatch>,
+    schema: &str,
+    num_chunks: usize,
+) -> PyResult<Vec<PyArrowType<ArrayData>>> {
+    let parsed_schema = deserialize::parse_schema(schema).map_err(to_py_err)?;
+    let serialized = serialize::serialize_record_batch(data.0, &parsed_schema, num_chunks)
+        .map_err(to_py_err)?;
+    Ok(serialized
+        .into_iter()
+        .map(|x| PyArrowType(x.into_data()))
+        .collect())
 }
 
 /// A Python module implemented in Rust.


### PR DESCRIPTION
  1. Arrow column naming — ruhvro/src/schema_translate.rs

  - Nested record fields: removed the format!("{}.{}", name.fullname(None), field.name) prefix; nested fields now use their bare Avro field.name like top-level fields do.
  - Enum-typed fields: stopped unconditionally overriding the caller-supplied field name with the enum type's FQDN; now prefers the caller-supplied name and only falls back to the enum's fullname when no name
   is provided.
  - Added test_field_names_use_avro_field_name to lock in the new behavior.

  2. Name-based serialization validation — ruhvro/src/serialization_containers.rs

  - StructArrayContainer::try_new now builds a name → index map from the Arrow struct, then iterates Avro fields and looks each up by name. A missing column produces an anyhow! error listing what was actually
   present. Applies recursively to nested structs since they flow through the same constructor.
  - serialize signature changed from -> GenericBinaryArray<i32> to -> anyhow::Result<...> so the validation error propagates instead of panicking.

  3. Error propagation in serialize_record_batch — ruhvro/src/serialize.rs

  - .par_iter().map(...).collect() now collects directly into Result<Vec<_>> (one fewer Ok(...) wrap).
  - Added two tests: test_serialize_matches_columns_by_name (reordered columns succeed, bytes match) and test_serialize_errors_on_missing_column (missing column returns a clean error).

  4. Doctest / README sync — ruhvro/src/lib.rs, ruhvro/README.md

  - Added .unwrap() on per_datum_deserialize and serialize_record_batch calls in the module doctest and the matching README snippet to match the now-Result-returning APIs.

  5. PyO3 wrapper — src/lib.rs

  - Rewrote to compile against the new Result-returning core APIs.
  - All entry points (deserialize_array, deserialize_array_threaded, serialize_record_batch) and per-element extract calls now use .map_err(to_py_err)? to convert anyhow::Error → PyValueError. Bad input now
  surfaces as a Python ValueError instead of a Rust panic.

  6. Flaky test fix — ruhvro/src/complex.rs

  - test_map_array no longer asserts a fixed ["my_key", "second"] key order (broken by HashMap iteration randomness). Now zips key/value into pairs, sorts by key, and asserts against the sorted expected list.
   Verified non-flaky over 5 isolated runs.
